### PR TITLE
Validate thrift models

### DIFF
--- a/elixir-thrift/lib/elixir_thrift/binary.ex
+++ b/elixir-thrift/lib/elixir_thrift/binary.ex
@@ -6,32 +6,34 @@ defmodule ElixirThrift.Binary do
     try do
 
       with({:ok, memory_buffer_transport} <- :thrift_memory_buffer.new(record_binary),
-           {:ok, binary_protocol} <- :thrift_binary_protocol.new(memory_buffer_transport),
-           {_, {:ok, record}} <- :thrift_protocol.read(binary_protocol, struct_definition)) do
+        {:ok, binary_protocol} <- :thrift_binary_protocol.new(memory_buffer_transport),
+        {_, {:ok, record}} <- :thrift_protocol.read(binary_protocol, struct_definition)) do
 
-             {:ok, ElixirThrift.Struct.to_elixir(record, struct_definition)}
-
+          {:ok, ElixirThrift.Struct.to_elixir(record, struct_definition)}
       end
 
     rescue _ ->
-        IO.puts "Cant decode"
-        {:error, :cant_decode}
+      IO.puts "Cant decode"
+      {:error, :cant_decode}
     end
   end
 
   #converts from elixir to binary using a Thrift struct definition
   #struct_definition should look something like this: {:struct, {:models_types, :User}}
   def elixir_to_binary(struct_to_binarise, struct_definition) do
-      with({:ok, tf} <- :thrift_memory_buffer.new_transport_factory(),
-          {:ok, pf} <- :thrift_binary_protocol.new_protocol_factory(tf, []),
-          {:ok, binary_protocol} <- pf.()) do
 
-            proto = ElixirThrift.Struct.to_erlang(struct_to_binarise, struct_definition)
-            |> write_proto(binary_protocol, struct_definition)
+    struct_to_binarise |> validate
 
-            {_, data} = :thrift_protocol.flush_transport(proto)
-            :erlang.iolist_to_binary(data)
-          end
+    with({:ok, tf} <- :thrift_memory_buffer.new_transport_factory(),
+      {:ok, pf} <- :thrift_binary_protocol.new_protocol_factory(tf, []),
+      {:ok, binary_protocol} <- pf.()) do
+
+        proto = ElixirThrift.Struct.to_erlang(struct_to_binarise, struct_definition)
+        |> write_proto(binary_protocol, struct_definition)
+
+        {_, data} = :thrift_protocol.flush_transport(proto)
+        :erlang.iolist_to_binary(data)
+      end
   end
 
   defp write_proto(thrift_struct, protocol, struct_definition) do
@@ -39,4 +41,12 @@ defmodule ElixirThrift.Binary do
     proto
   end
 
+  defp validate(struct) do
+    invalid =
+      struct
+      |> Map.values
+      |> Enum.any?(fn x -> x == :undefined end)
+
+    if (invalid), do: raise "Invalid model"
+  end
 end

--- a/elixir-thrift/thrift/models.thrift
+++ b/elixir-thrift/thrift/models.thrift
@@ -1,4 +1,4 @@
 struct User {
-  1: string name
-  2: i32 age
+  1: required string name
+  2: required i32 age
 }

--- a/ruby-thrift/thrift/models.thrift
+++ b/ruby-thrift/thrift/models.thrift
@@ -1,4 +1,4 @@
 struct User {
-  1: string name
-  2: i32 age
+  1: required string name
+  2: required i32 age
 }


### PR DESCRIPTION
Default value for unspecified fields in structs is `:undefined`. Before serializing we check for any `:undefined` fields. If any, that means that struct isn't valid and exception is raised. 
